### PR TITLE
Small Edits

### DIFF
--- a/lnprototest/__init__.py
+++ b/lnprototest/__init__.py
@@ -11,7 +11,7 @@ reference material, and the tutorial should get you started.
 
 """
 from .errors import EventError, SpecFileError
-from .event import Event, Connect, Disconnect, Msg, RawMsg, ExpectMsg, MustNotMsg, Block, ExpectTx, FundChannel, Invoice, AddHtlc, CheckEq, ExpectError, ResolvableInt, ResolvableStr, Resolvable, ResolvableBool, msat, negotiated, DualFundAccept
+from .event import Event, Connect, Disconnect, Msg, RawMsg, ExpectMsg, MustNotMsg, Block, ExpectTx, FundChannel, Invoice, AddHtlc, CheckEq, ExpectError, ResolvableInt, ResolvableStr, Resolvable, ResolvableBool, msat, negotiated, DualFundAccept, Wait
 from .structure import Sequence, OneOf, AnyOrder, TryAll
 from .runner import Runner, Conn, remote_revocation_basepoint, remote_payment_basepoint, remote_delayed_payment_basepoint, remote_htlc_basepoint, remote_per_commitment_point, remote_per_commitment_secret, remote_funding_pubkey, remote_funding_privkey
 from .dummyrunner import DummyRunner
@@ -84,4 +84,5 @@ __all__ = [
     "Funding",
     "regtest_hash",
     "privkey_expand",
+    "Wait",
 ]

--- a/lnprototest/event.py
+++ b/lnprototest/event.py
@@ -5,6 +5,7 @@ import collections
 import os.path
 import io
 import struct
+import time
 from .errors import SpecFileError, EventError
 from .namespace import event_namespace
 from .utils import check_hex
@@ -153,6 +154,17 @@ class Msg(PerConnEvent):
         message.write(binmsg)
         runner.recv(self, self.find_conn(runner), binmsg.getvalue())
         msg_to_stash(runner, self, message)
+        return True
+
+
+class Wait(PerConnEvent):
+    """Put a delay in a test, to allow time for things to happen
+       on the node's end """
+    def __init__(self, delay_s: int):
+        self.delay_s = delay_s
+
+    def action(self, runner: 'Runner') -> bool:
+        time.sleep(self.delay_s)
         return True
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-pyln.proto==0.8.3
+pyln.proto==0.8.4
 pyln.bolt1==1.0.1.137
 pyln.bolt2==1.0.1.137
 pyln.bolt4==1.0.1.137
 pyln.bolt7==1.0.1.137
 pyln.testing
-coincurve
+coincurve==13.0.0
 python-bitcoinlib==0.11.0
 mypy
 crc32c

--- a/tests/test_bolt7-20-query_channel_range.py
+++ b/tests/test_bolt7-20-query_channel_range.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
 # Tests for gossip_timestamp_filter
-from lnprototest import Connect, Block, ExpectMsg, Msg, RawMsg, Funding, Event, Side, MustNotMsg, OneOf, Runner, bitfield, TryAll, Sequence, regtest_hash, CheckEq, EventError, event_namespace
+from lnprototest import Connect, Block, ExpectMsg, Msg, RawMsg, Funding, Event, Side, MustNotMsg, OneOf, Runner, bitfield, TryAll, Sequence, regtest_hash, CheckEq, EventError, event_namespace, Wait
 from helpers import tx_spendable, utxo
 from typing import Optional
 import unittest
@@ -212,6 +212,11 @@ def test_query_channel_range(runner: Runner) -> None:
             RawMsg(funding2.channel_announcement('109x1x0', '')),
             RawMsg(update_109x1x0_LOCAL),
             RawMsg(update_109x1x0_REMOTE),
+
+            # c-lightning gets a race condition if we dont wait for
+            # these updates to be added to the gossip store
+            # FIXME: convert to explicit signal
+            Wait(0.7),
 
             # New peer connects, with gossip_query option.
             Connect(connprivkey='05'),

--- a/tests/test_bolt7-20-query_channel_range.py
+++ b/tests/test_bolt7-20-query_channel_range.py
@@ -256,7 +256,7 @@ def test_query_channel_range(runner: Runner) -> None:
                  OneOf(ExpectMsg('reply_channel_range',
                                  chain_hash=regtest_hash,
                                  first_blocknum=109,
-                                 number_of_blocks=4294967295),
+                                 number_of_blocks=4294967186),
                        # Could truncate number_of_blocks.
                        ExpectMsg('reply_channel_range',
                                  chain_hash=regtest_hash,


### PR DESCRIPTION
Still have some problems locally with `pyln.testing` wanting `python-bitcoinlib` of version 0.10.2. We should have a new pypi update of `pyln-testing` after the release though, which should allow us to peg the requirement to `pyln-testing==0.10.0` and hopefully fix this once and for all.