### PR TITLE
Give the possibility to run lnprototest with different version of bitcoin core.

### DIFF
--- a/lnprototest/clightning/clightning.py
+++ b/lnprototest/clightning/clightning.py
@@ -8,7 +8,6 @@ import hashlib
 import pyln.client
 import pyln.proto.wire
 import os
-import logging
 import shutil
 import subprocess
 import tempfile


### PR DESCRIPTION
The object of this commit is to give the possibility to run different the test with different versions of Bitcoin core without put change to the code (when it is not necessary). However, the object of this commit is not to support a very old version of bitcoin core, but only the version around the actual official version of it.

P.S. This commit is introduced because with bitcoin core 0.21.0 I receive an exception because it doesn't create by default the "default" wallet, but the user need to call createwallet.

I use the logging module to print the version of bitcoin to make sure a user that want run a particular version of bitcoin core that the test are ran with the correct version, but I think it is not a good place where print it.