### PR TITLE
Removed deprecated crc32c API and fix the version crc32c into requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ pyln.testing
 coincurve==13.0.0
 python-bitcoinlib==0.11.0
 mypy
-crc32c
+crc32c==2.2

--- a/tests/test_bolt7-20-query_channel_range.py
+++ b/tests/test_bolt7-20-query_channel_range.py
@@ -109,7 +109,7 @@ def calc_checksum(update: Message) -> int:
     #     * [`byte`:`message_flags`]
 
     # Note: 2 bytes for `type` field
-    return crc32c.crc32(buf[2 + 64:2 + 64 + 32 + 8] + buf[2 + 64 + 32 + 8 + 4:])
+    return crc32c.crc32c(buf[2 + 64:2 + 64 + 32 + 8] + buf[2 + 64 + 32 + 8 + 4:])
 
 
 def update_checksums(update1: Optional[Message], update2: Optional[Message]) -> str:


### PR DESCRIPTION
Remove the warning message in the c-lightning test about the crc32c dependence 