### PR TITLE
clightning: explicitly set 'leases-only' to false

### DIFF
--- a/lnprototest/clightning/clightning.py
+++ b/lnprototest/clightning/clightning.py
@@ -276,7 +276,8 @@ class Runner(lnprototest.Runner):
     def accept_add_fund(self, event: Event) -> None:
         self.rpc.call('funderupdate', {'policy': 'match',
                                        'policy_mod': 100,
-                                       'fuzz_percent': 0})
+                                       'fuzz_percent': 0,
+                                       'leases_only': False})
 
     def addhtlc(self, event: Event, conn: Conn,
                 amount: int, preimage: str) -> None:


### PR DESCRIPTION
clightning's default is going to switch to "true", so we explicitly set it to false for these tests.