### PR TITLE
Update dependence and remove pyln.testing dependences

### DIFF
--- a/lnprototest/__init__.py
+++ b/lnprototest/__init__.py
@@ -20,7 +20,7 @@ from .bitfield import bitfield, has_bit, bitfield_len
 from .signature import SigType, Sig
 from .keyset import KeySet
 from .commit_tx import Commit, HTLC, UpdateCommit
-from .utils import Side, regtest_hash, privkey_expand
+from .utils import Side, regtest_hash, privkey_expand, wait_for
 from .funding import AcceptFunding, CreateFunding, CreateDualFunding, Funding, AddInput, AddOutput, FinalizeFunding, AddWitnesses
 from .proposals import dual_fund_csv, channel_type_csv
 

--- a/lnprototest/clightning/clightning.py
+++ b/lnprototest/clightning/clightning.py
@@ -18,8 +18,8 @@ from concurrent import futures
 from ephemeral_port_reserve import reserve
 from lnprototest.backend import Bitcoind
 from lnprototest import Event, EventError, SpecFileError, KeySet, Conn, namespace, MustNotMsg
+from lnprototest import wait_for
 from typing import Dict, Any, Callable, List, Optional, cast
-from pyln.testing.utils import wait_for
 
 TIMEOUT = int(os.getenv("TIMEOUT", "30"))
 LIGHTNING_SRC = os.path.join(os.getcwd(), os.getenv("LIGHTNING_SRC", '../lightning/'))

--- a/lnprototest/utils.py
+++ b/lnprototest/utils.py
@@ -1,6 +1,7 @@
 #! /usr/bin/python3
 import string
 import coincurve
+import time
 from enum import IntEnum
 
 # regtest chain hash (hash of regtest genesis block)
@@ -28,3 +29,16 @@ def check_hex(val: str, digits: int) -> str:
 def privkey_expand(secret: str) -> coincurve.PrivateKey:
     # Privkey can be truncated, since we use tiny values a lot.
     return coincurve.PrivateKey(bytes.fromhex(secret).rjust(32, bytes(1)))
+
+
+def wait_for(success, timeout=180):
+    start_time = time.time()
+    interval = 0.25
+    while not success():
+        time_left = start_time + timeout - time.time()
+        if time_left <= 0:
+            raise ValueError("Timeout while waiting for {}", success)
+        time.sleep(min(interval, time_left))
+        interval *= 2
+        if interval > 5:
+            interval = 5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-pyln.proto>=0.8.4
+pyln.proto>=0.10.0
 pyln.bolt1==1.0.1.137
 pyln.bolt2==1.0.1.137
 pyln.bolt4==1.0.1.137
 pyln.bolt7==1.0.1.137
-pyln.testing
 coincurve==13.0.0
 python-bitcoinlib==0.11.0
-mypy
+mypy==0.910
 crc32c==2.2
+ephemeral-port-reserve>=1.1.4


### PR DESCRIPTION
As mentioned correctly in issue #17 the pyln.testing require the postgress dependencies, but inside the lnprototest there are no any reason to use the package pyln.testing, because is used only util functions. With this commit, I removed the dependencies, and I reproduce the few lines of code that are imported from the pyln package.

Change-log: Remove pyln.testing to remove the dependencies problem with pip

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>