### PR TITLE
Generated temporary path too long for Mac OS X

### DIFF
--- a/lnprototest/clightning/clightning.py
+++ b/lnprototest/clightning/clightning.py
@@ -43,7 +43,7 @@ class Runner(lnprototest.Runner):
         self.fundchannel_future: Optional[Any] = None
         self.is_fundchannel_kill = False
 
-        directory = tempfile.mkdtemp(prefix='lnprototest-clightning-')
+        directory = tempfile.mkdtemp(prefix='lnpt-cl-')
         self.bitcoind = Bitcoind(directory)
         self.bitcoind.start()
         self.executor = futures.ThreadPoolExecutor(max_workers=20)


### PR DESCRIPTION
Mac OS X limits rpc full paths to 104 characters. Using mkdtemp results in a path that is too long.

On Mac OS X 11.4, Xcode 12.5.1 (12E507), the rpc file was placed at:
/var/folders/6k/gjk2k1wn6yb38kx5480jdhdh0000gn/T/lnprototest-clightning-p_xswkz9/lightningd/regtest/lightning-rpc
which is 113 characters (9 too long).

Shortening the prefix gets us below the limit.