### PR TITLE
lnprototest: improve the code is the bitcoin core is running

### DIFF
--- a/lnprototest/backend/bitcoind.py
+++ b/lnprototest/backend/bitcoind.py
@@ -114,16 +114,14 @@ class Bitcoind(Backend):
 
     def __is__bitcoind_ready(self) -> bool:
         """Check if bitcoind is ready during the execution"""
-        if self.rpc is None:
+        if self.proc is None:
             # Sanity check
             raise ValueError("bitcoind not initialized")
 
-        try:
-            self.btc_version = self.rpc.getnetworkinfo()
-            return True
-        except Exception as ex:
-            logging.debug(f"{ex}")
-            return False
+        # Wait for it to startup.
+        while b"Done loading" not in self.proc.stdout.readline():
+            pass
+        return True
 
     def start(self) -> None:
         if self.rpc is None:


### PR DESCRIPTION
Due the refactoring the following code was introduced

```
    def __is__bitcoind_ready(self) -> bool:
        """Check if bitcoind is ready during the execution"""
        if self.rpc is None:
            # Sanity check
            raise ValueError("bitcoind not initialized")

        try:
            self.btc_version = self.rpc.getnetworkinfo()
            return True
        except Exception as ex:
            logging.debug(f"{ex}")
            return False
```

That it is not smarter for a language low by default like python.

using instead the Rusty version, much better 

```
  def __is__bitcoind_ready(self) -> bool:
        """Check if bitcoind is ready during the execution"""
        if self.proc is None:
            # Sanity check
            raise ValueError("bitcoind not initialized")

        # Wait for it to startup.
        while b"Done loading" not in self.proc.stdout.readline():
            pass
        return True
```

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>