### PR TITLE
tests: slow down the fixtures scope from session to scope

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ def pytest_addoption(parser: Any) -> None:
     )
 
 
-@pytest.fixture(scope="session")  # type: ignore
+@pytest.fixture()  # type: ignore
 def runner(pytestconfig: Any) -> Any:
     parts = pytestconfig.getoption("runner").rpartition(".")
     runner = importlib.import_module(parts[0]).__dict__[parts[2]](pytestconfig)


### PR DESCRIPTION
The scope session can cause problems when two tests are running in parallel, because if the lnprototest is not new, it is possible that we are sharing the process.

Changelog-Fixed: Fix the fixture scope of the runner.

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>