### PR TITLE
clightning Runner: start bitcoind before clightning

### DIFF
--- a/lnprototest/clightning/clightning.py
+++ b/lnprototest/clightning/clightning.py
@@ -116,6 +116,11 @@ class Runner(lnprototest.Runner):
         self.logger.debug("[START]")
         self.__init_sandbox_dir()
         self.bitcoind = Bitcoind(self.directory)
+        try:
+            self.bitcoind.start()
+        except Exception as ex:
+            self.logger.debug(f"Exception with message {ex}")
+        self.logger.debug("RUN Bitcoind")
         self.proc = subprocess.Popen(
             [
                 "{}/lightningd/lightningd".format(LIGHTNING_SRC),
@@ -138,11 +143,6 @@ class Runner(lnprototest.Runner):
             + self.startup_flags
         )
         self.running = True
-        try:
-            self.bitcoind.start()
-        except Exception as ex:
-            self.logger.debug(f"Exception with message {ex}")
-        self.logger.debug("RUN Bitcoind")
         self.rpc = pyln.client.LightningRpc(
             os.path.join(self.lightning_dir, "regtest", "lightning-rpc")
         )


### PR DESCRIPTION
Ran into a bug where clightning exits before bitcoind is ready for an rpc connection. 
Bitcoind.start() already confirms rpc connection before returning, which can be
taken advantage of be calling the bitcoind and clightning in order.
```
--------------- Captured stderr call ------------------
Could not connect to bitcoind using bitcoin-cli. Is bitcoind running?

Make sure you have bitcoind running and that bitcoin-cli is able to connect to bitcoind.

You can verify that your Bitcoin Core installation is ready for use by running:

    $ bitcoin-cli -regtest -rpcport=39071 -rpcuser=... -rpcpassword=... echo 'hello world'

The Bitcoin backend died.
DEBUG:lnprototest.runner:RUN Bitcoind
DEBUG:lnprototest.runner:RUN c-lightning
```
