### PR TITLE
cln: Use full hostname:port `rpcconnect` instead of just `rpcport`

### DIFF
--- a/lnprototest/clightning/clightning.py
+++ b/lnprototest/clightning/clightning.py
@@ -152,7 +152,7 @@ class Runner(lnprototest.Runner):
                 "--network=regtest",
                 "--bitcoin-rpcuser=rpcuser",
                 "--bitcoin-rpcpassword=rpcpass",
-                "--bitcoin-rpcport={}".format(self.bitcoind.port),
+                f"--bitcoin-rpcconnect=localhost:{self.bitcoind.port}",
                 "--log-level=debug",
                 "--log-file=log",
                 "--htlc-maximum-msat=2000sat",


### PR DESCRIPTION
I was having some difficulty running lnprototest locally because it was reading my `bitcoin.conf` which points to a remote `bitcoind` that doesn't have `regtest` running. This caused tests to hang and time out since it couldn't connect to `bitcoind`. This now specifies that we want to connect to the local regtest node we just spun up.