### PR TITLE
fix: cleanup funding code and avoid raise multiple exceptions

### DIFF
--- a/tests/test_bolt2-01-close_channel.py
+++ b/tests/test_bolt2-01-close_channel.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python3
 """
 testing bolt2 closing channel operation described in the lightning network speck
 https://github.com/lightning/bolts/blob/master/02-peer-protocol.md#channel-close

--- a/tests/test_bolt2-01-open_channel.py
+++ b/tests/test_bolt2-01-open_channel.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python3
 # Variations on open_channel, accepter + opener perspectives
 
 from lnprototest import (


### PR DESCRIPTION
when we send a message from cln to the runner we should be in an async mode, and this
is implemented with a thread pool. 

Now, when there are multiple failures (exception at the same time) the 
python runtime mess up all the stack trace and this makes the debugging
of cln log is no longer possible in the console.

So this try to fix this problem

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>