### PR TITLE
Update documentation c-lightning references to core-lightning

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -12,7 +12,7 @@ For every test, there is a runner which wraps a particular node
 implementation: using the default "DummyRunner" helps debug the tests
 themselves.
 
-A test consists of one or more Event (e.g. send a message, receive a
+A test consists of one or more Events (e.g. send a message, receive a
 message), in a DAG.  The test runner repeats the test until every
 Event has been covered.  The most important event is probably
 TryAll(), which gives multiple alternative paths of Events, each of
@@ -79,7 +79,7 @@ To add a new runner, you'll need to create a new subclass of Runner, that
 fills in the Runner API. You can find a good skeleton for a new runner in
 `lnprototest/dummyrunner.py`
 
-A completed c-lightning example runner can be found in `lnprototest/clightning/clightning.py`
+A completed core-lightning example runner can be found in `lnprototest/clightning/clightning.py`
 
 Here's a short outline of the current expected methods for a Runner.
 
@@ -97,7 +97,7 @@ Here's a short outline of the current expected methods for a Runner.
 
 - `connect`: Create a connection to the node under test using the provided `connprivkey`.
 - `getblockheight`: Return the blockcount from bitcoind
-- `trim_blocks`: invalidate bitcoind blocks until `newheight`
+- `trim_blocks`: Invalidate bitcoind blocks until `newheight`
 - `add_blocks`: Send provided `txs` (if any). Generate `n` new blocks.
 - `disconnect`: Implemented in the parent Runner, not necessary to implement in child unless necessary.
 - `recv`: Send `outbuf` over `conn` to node under test
@@ -105,7 +105,7 @@ Here's a short outline of the current expected methods for a Runner.
 - `init_rbf`: For v2 channel opens, initiates an RBF attempt. Same as `fundchannel`, must not block.
 - `invoice`: Generate an invoice from the node under test for the given amount and preimage
 - `accept_add_fund`: Configure the node under test to contribute to any incoming v2 open channel offers.
-- `addhtlc`: Add the provided htlc to the the node. clightning does this via the `sendpay` command
+- `addhtlc`: Add the provided htlc to the the node. core lightning does this via the `sendpay` command
 - `get_output_message`: Read a message from the node's connection
 - `expect_tx`: Wait for the provided txid to appear in the mempool
 - `check_error`: Gets message from connection and returns it as hex. Also calls parent Runner method (which marks this as an `expected_error`)
@@ -113,7 +113,7 @@ Here's a short outline of the current expected methods for a Runner.
 
 
 ### Passing cmdline args to the Runner
-Note that the c-lightning runner, in `__init__`, converts
+Note that the core-lightning runner, in `__init__`, converts
 cmdline `runner_args` into a `startup_flag` array, which are then
 passed to the node at `start`
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Here are some other useful pytest options:
 ### Running Against A Real Node.
 
 The more useful way to run is to use an existing implementation. So
-far, c-lightning is supported.  You will need:
+far, core-lightning is supported.  You will need:
 
 1. `bitcoind` installed, and in your path.
 2. [`lightningd`](https://github.com/ElementsProject/lightning/) compiled with

--- a/lnprototest/backend/bitcoind.py
+++ b/lnprototest/backend/bitcoind.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-# This script exercises the c-lightning implementation
+# This script exercises the core-lightning implementation
 
 # Released by Rusty Russell under CC0:
 # https://creativecommons.org/publicdomain/zero/1.0/

--- a/lnprototest/clightning/__init__.py
+++ b/lnprototest/clightning/__init__.py
@@ -1,4 +1,4 @@
-"""Runner for the c-lightning implementation.
+"""Runner for the core-lightning implementation.
 
 This is adapted from the older testcases, so it is overly prescriptive
 of how the node is configured.  A more modern implementation would simply

--- a/lnprototest/clightning/clightning.py
+++ b/lnprototest/clightning/clightning.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-# This script exercises the c-lightning implementation
+# This script exercises the core-lightning implementation
 
 # Released by Rusty Russell under CC0:
 # https://creativecommons.org/publicdomain/zero/1.0/
@@ -163,18 +163,18 @@ class Runner(lnprototest.Runner):
         self.rpc = pyln.client.LightningRpc(
             os.path.join(self.lightning_dir, "regtest", "lightning-rpc")
         )
-        self.logger.debug("RUN c-lightning")
+        self.logger.debug("RUN core-lightning")
 
         def node_ready(rpc: pyln.client.LightningRpc) -> bool:
             try:
                 rpc.getinfo()
                 return True
             except Exception as ex:
-                logging.debug(f"waiting for c-lightning: Exception received {ex}")
+                logging.debug(f"waiting for core-lightning: Exception received {ex}")
                 return False
 
         wait_for(lambda: node_ready(self.rpc))
-        logging.debug("Waited fro c-lightning")
+        logging.debug("Waited for core-lightning")
 
         # Make sure that we see any funds that come to our wallet
         for i in range(5):
@@ -196,7 +196,7 @@ class Runner(lnprototest.Runner):
         if print_logs:
             log_path = f"{self.lightning_dir}/regtest/log"
             with open(log_path) as log:
-                self.logger.info("---------- c-lightning logging ----------------")
+                self.logger.info("---------- core-lightning logging ----------------")
                 self.logger.info(log.read())
                 # now we make a backup of the log
                 shutil.copy(

--- a/tests/test_bolt2-01-open_channel.py
+++ b/tests/test_bolt2-01-open_channel.py
@@ -79,7 +79,7 @@ def test_open_channel(runner: Runner) -> None:
                     channel_reserve_satoshis=9998,
                     htlc_minimum_msat=0,
                     feerate_per_kw=253,
-                    # We use 5, because c-lightning runner uses 6, so this is different.
+                    # We use 5, because core-lightning runner uses 6, so this is different.
                     to_self_delay=5,
                     max_accepted_htlcs=483,
                     funding_pubkey=pubkey_of(local_funding_privkey),
@@ -186,7 +186,7 @@ def test_open_channel(runner: Runner) -> None:
                     htlc_minimum_msat=0,
                     minimum_depth=3,
                     max_accepted_htlcs=483,
-                    # We use 5, because c-lightning runner uses 6, so this is different.
+                    # We use 5, because core-lightning runner uses 6, so this is different.
                     to_self_delay=5,
                     funding_pubkey=pubkey_of(local_funding_privkey),
                     revocation_basepoint=local_keyset.revocation_basepoint(),

--- a/tests/test_bolt2-20-open_channel_accepter.py
+++ b/tests/test_bolt2-20-open_channel_accepter.py
@@ -244,7 +244,7 @@ def test_open_accepter_no_inputs(runner: Runner, with_proposal: Any) -> None:
             htlc_minimum_msat=0,
             funding_feerate_perkw=253,
             commitment_feerate_perkw=253,
-            # We use 5, because c-lightning runner uses 6, so this is different.
+            # We use 5, because core-lightning runner uses 6, so this is different.
             to_self_delay=5,
             max_accepted_htlcs=483,
             locktime=0,
@@ -470,7 +470,7 @@ def test_open_accepter_with_inputs(runner: Runner, with_proposal: Any) -> None:
             htlc_minimum_msat=0,
             funding_feerate_perkw=253,
             commitment_feerate_perkw=253,
-            # We use 5, because c-lightning runner uses 6, so this is different.
+            # We use 5, because core-lightning runner uses 6, so this is different.
             to_self_delay=5,
             max_accepted_htlcs=483,
             locktime=100,
@@ -678,7 +678,7 @@ def test_open_opener_no_input(runner: Runner, with_proposal: Any) -> None:
             htlc_minimum_msat=0,
             minimum_depth=3,
             max_accepted_htlcs=483,
-            # We use 5, to be different from c-lightning runner who uses 6
+            # We use 5, to be different from core-lightning runner who uses 6
             to_self_delay=5,
             funding_pubkey=pubkey_of(local_funding_privkey),
             revocation_basepoint=local_keyset.revocation_basepoint(),
@@ -871,7 +871,7 @@ def test_open_opener_with_inputs(runner: Runner, with_proposal: Any) -> None:
             htlc_minimum_msat=0,
             minimum_depth=3,
             max_accepted_htlcs=483,
-            # We use 5, to be different from c-lightning runner who uses 6
+            # We use 5, to be different from core-lightning runner who uses 6
             to_self_delay=5,
             funding_pubkey=pubkey_of(local_funding_privkey),
             revocation_basepoint=local_keyset.revocation_basepoint(),
@@ -1088,7 +1088,7 @@ def test_df_accepter_opener_underpays_fees(runner: Runner, with_proposal: Any) -
             htlc_minimum_msat=0,
             funding_feerate_perkw=1000,
             commitment_feerate_perkw=253,
-            # We use 5, because c-lightning runner uses 6, so this is different.
+            # We use 5, because core-lightning runner uses 6, so this is different.
             to_self_delay=5,
             max_accepted_htlcs=483,
             locktime=100,
@@ -1296,7 +1296,7 @@ def test_df_opener_accepter_underpays_fees(runner: Runner, with_proposal: Any) -
             htlc_minimum_msat=0,
             minimum_depth=3,
             max_accepted_htlcs=483,
-            # We use 5, to be different from c-lightning runner who uses 6
+            # We use 5, to be different from core-lightning runner who uses 6
             to_self_delay=5,
             funding_pubkey=pubkey_of(local_funding_privkey),
             revocation_basepoint=local_keyset.revocation_basepoint(),
@@ -1789,7 +1789,7 @@ def test_rbf_accepter(runner: Runner, with_proposal: Any) -> None:
             htlc_minimum_msat=0,
             funding_feerate_perkw=253,
             commitment_feerate_perkw=253,
-            # We use 5, because c-lightning runner uses 6, so this is different.
+            # We use 5, because core-lightning runner uses 6, so this is different.
             to_self_delay=5,
             max_accepted_htlcs=483,
             locktime=0,
@@ -1907,7 +1907,7 @@ def test_rbf_opener(runner: Runner, with_proposal: Any) -> None:
             htlc_minimum_msat=0,
             minimum_depth=3,
             max_accepted_htlcs=483,
-            # We use 5, to be different from c-lightning runner who uses 6
+            # We use 5, to be different from core-lightning runner who uses 6
             to_self_delay=5,
             funding_pubkey=pubkey_of(local_funding_privkey),
             revocation_basepoint=local_keyset.revocation_basepoint(),
@@ -2003,7 +2003,7 @@ def test_rbf_accepter_channel_ready(runner: Runner, with_proposal: Any) -> None:
             htlc_minimum_msat=0,
             funding_feerate_perkw=253,
             commitment_feerate_perkw=253,
-            # We use 5, because c-lightning runner uses 6, so this is different.
+            # We use 5, because core-lightning runner uses 6, so this is different.
             to_self_delay=5,
             max_accepted_htlcs=483,
             locktime=0,
@@ -2144,7 +2144,7 @@ def test_rbf_opener_channel_ready(runner: Runner, with_proposal: Any) -> None:
             htlc_minimum_msat=0,
             minimum_depth=3,
             max_accepted_htlcs=483,
-            # We use 5, to be different from c-lightning runner who uses 6
+            # We use 5, to be different from core-lightning runner who uses 6
             to_self_delay=5,
             funding_pubkey=pubkey_of(local_funding_privkey),
             revocation_basepoint=local_keyset.revocation_basepoint(),
@@ -2266,7 +2266,7 @@ def test_rbf_accepter_forgets(runner: Runner, with_proposal: Any) -> None:
             htlc_minimum_msat=0,
             funding_feerate_perkw=253,
             commitment_feerate_perkw=253,
-            # We use 5, because c-lightning runner uses 6, so this is different.
+            # We use 5, because core-lightning runner uses 6, so this is different.
             to_self_delay=5,
             max_accepted_htlcs=483,
             locktime=0,
@@ -2440,7 +2440,7 @@ def test_rbf_opener_forgets(runner: Runner, with_proposal: Any) -> None:
             htlc_minimum_msat=0,
             minimum_depth=3,
             max_accepted_htlcs=483,
-            # We use 5, to be different from c-lightning runner who uses 6
+            # We use 5, to be different from core-lightning runner who uses 6
             to_self_delay=5,
             funding_pubkey=pubkey_of(local_funding_privkey),
             revocation_basepoint=local_keyset.revocation_basepoint(),
@@ -2601,7 +2601,7 @@ def test_rbf_not_valid_rbf(runner: Runner, with_proposal: Any) -> None:
             htlc_minimum_msat=0,
             funding_feerate_perkw=253,
             commitment_feerate_perkw=253,
-            # We use 5, because c-lightning runner uses 6, so this is different.
+            # We use 5, because core-lightning runner uses 6, so this is different.
             to_self_delay=5,
             max_accepted_htlcs=483,
             locktime=0,

--- a/tests/test_bolt2-30-channel_type-open-accept-tlvs.py
+++ b/tests/test_bolt2-30-channel_type-open-accept-tlvs.py
@@ -59,7 +59,7 @@ def test_open_channel(runner: Runner, with_proposal: Any) -> None:
             channel_reserve_satoshis=9998,
             htlc_minimum_msat=0,
             feerate_per_kw=253,
-            # We use 5, because c-lightning runner uses 6, so this is different.
+            # We use 5, because core-lightning runner uses 6, so this is different.
             to_self_delay=5,
             max_accepted_htlcs=483,
             funding_pubkey=pubkey_of(local_funding_privkey),
@@ -118,7 +118,7 @@ def test_open_channel_empty_type(runner: Runner, with_proposal: Any) -> None:
             channel_reserve_satoshis=9998,
             htlc_minimum_msat=0,
             feerate_per_kw=253,
-            # We use 5, because c-lightning runner uses 6, so this is different.
+            # We use 5, because core-lightning runner uses 6, so this is different.
             to_self_delay=5,
             max_accepted_htlcs=483,
             funding_pubkey=pubkey_of(local_funding_privkey),
@@ -183,7 +183,7 @@ def test_open_channel_bad_type(runner: Runner, with_proposal: Any) -> None:
             channel_reserve_satoshis=9998,
             htlc_minimum_msat=0,
             feerate_per_kw=253,
-            # We use 5, because c-lightning runner uses 6, so this is different.
+            # We use 5, because core-lightning runner uses 6, so this is different.
             to_self_delay=5,
             max_accepted_htlcs=483,
             funding_pubkey=pubkey_of(local_funding_privkey),

--- a/tests/test_bolt7-20-query_channel_range.py
+++ b/tests/test_bolt7-20-query_channel_range.py
@@ -247,7 +247,7 @@ def test_query_channel_range(runner: Runner) -> None:
         RawMsg(funding2.channel_announcement("109x1x0", "")),
         RawMsg(update_109x1x0_LOCAL),
         RawMsg(update_109x1x0_REMOTE),
-        # c-lightning gets a race condition if we dont wait for
+        # core-lightning gets a race condition if we dont wait for
         # these updates to be added to the gossip store
         # FIXME: convert to explicit signal
         Wait(1),


### PR DESCRIPTION
This is an update in the code comments to match name change for the Lightning implementation from c-lightning to core-lightning. I referred to this [article](https://blog.blockstream.com/en-c-lightning-is-now-core-lightning/)