### PR TITLE
fix: add Wait event to allow to slow down lnptototest

### DIFF
--- a/tests/test_bolt2-01-open_channel.py
+++ b/tests/test_bolt2-01-open_channel.py
@@ -1,5 +1,4 @@
 # Variations on open_channel, accepter + opener perspectives
-import pytest
 from lnprototest import (
     TryAll,
     Block,
@@ -168,9 +167,6 @@ def test_open_channel_from_accepter_side(runner: Runner) -> None:
     run_runner(runner, merge_events_sequences(connections_events, test_events))
 
 
-@pytest.mark.skip(
-    reason="skip this test because the when we try to connect to lnprototest the connection fails"
-)
 def test_open_channel_opener_side(runner: Runner) -> None:
     local_funding_privkey = "20"
     local_keyset = gen_random_keyset(int(local_funding_privkey))


### PR DESCRIPTION
There is some case where lnprototest send the message too fast, well lnprototest is always too fast but in most case, we simulate the `time.sleep` inside the ExpectedMsg that iterates for a while till the message is not received.

This is no longer true if lnprototest sends a message and the next steps is not the ExpectedMsg or equal but a message that required that the message sent to lnprototest is already processed, like in the `FundChannel(...)` case.

So this PR is introducing a new Event `Wait` that will allow us to wait some time before processing the next message 

Fixes https://github.com/rustyrussell/lnprototest/issues/74