### PR TITLE
docs: configure the changelog for the next release

### DIFF
--- a/changelog.json
+++ b/changelog.json
@@ -1,0 +1,16 @@
+{
+  "package_name": "lnprototest",
+  "version": "v0.0.2",
+  "api": {
+    "name": "github",
+    "repository": "rustyrussell/lnprototest",
+    "branch": "macros/changelog"
+  },
+  "generation_method": {
+    "name": "semver-v2",
+    "header_filter": false
+  },
+  "serialization_method": {
+    "name": "md"
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "lnprototest"
 version = "0.0.2"
 description = "Spec protocol tests for lightning network implementations"
-authors = ["Rusty Russell <rusty@blockstream.com>"]
+authors = ["Rusty Russell <rusty@blockstream.com>", "Vincenzo Palazzo <vincenzopalazzodev@gmail.com>"]
 license = "MIT"
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
This uses a changelog extractor available here https://github.com/vincenzopalazzo/changelog.dart which for now works with the Github API.

But it is fine for now, I do not want use the extra script!

With this, we are tagging the version v0.0.2 of lnprototest