### PR TITLE
tests/test_bolt2-30-channel_type-open-accept-tlvs.py: remove compulsory feature

### DIFF
--- a/tests/test_bolt2-30-channel_type-open-accept-tlvs.py
+++ b/tests/test_bolt2-30-channel_type-open-accept-tlvs.py
@@ -165,7 +165,7 @@ def test_open_channel_bad_type(runner: Runner, with_proposal: Any) -> None:
         TryAll(
             # BOLT-a12da24dd0102c170365124782b46d9710950ac1 #9:
             # | 20/21 | `option_anchor_outputs`          | Anchor outputs
-            Msg("init", globalfeatures="", features=bitfield(12, 20)),
+            Msg("init", globalfeatures="", features=bitfield(12, 21)),
             # BOLT #9:
             # | 12/13 | `option_static_remotekey`        | Static key for remote output
             Msg("init", globalfeatures="", features=bitfield(12)),


### PR DESCRIPTION
Channel types does not require anchors!

This is needed for https://github.com/ElementsProject/lightning/pull/6209