### PR TITLE
feat: Open channel helper ignores announcement signatures

### DIFF
--- a/lnprototest/utils/ln_spec_utils.py
+++ b/lnprototest/utils/ln_spec_utils.py
@@ -206,21 +206,8 @@ def open_and_announce_channel_helper(
         ),
         # wait confirmations
         Block(blockheight=103, number=6),
-        # FIXME: implement all the utils function for the announcement_signatures
-        ExpectMsg(
-            "announcement_signatures",
-            channel_id=channel_id(),
-            short_channel_id=short_channel_id,
-            # TODO: How build signatures without hard coding it here?
-            node_signature="5ffb05bfb1ef2941cd26e02eea9bfcd6862a08dcfd58473cd1e7da879c2127d6650159c731ae07cd07ff00f4fe7d344aef7997384465f34d7c57add4795a7b09",
-            bitcoin_signature="138c93afb2013c39f959e70a163c3d6d8128cf72f8ae143f87b9d1fd6bb0ad30321116b9c58d69fca9fb33c214f681b664e53d5640abc2fdb972dc62a5571053",
-        ),
-        Msg(
-            "announcement_signatures",
-            channel_id=channel_id(),
-            short_channel_id=short_channel_id,
-            # TODO: How build signatures without hard coding it here?
-            node_signature="5ffb05bfb1ef2941cd26e02eea9bfcd6862a08dcfd58473cd1e7da879c2127d6650159c731ae07cd07ff00f4fe7d344aef7997384465f34d7c57add4795a7b09",
-            bitcoin_signature="138c93afb2013c39f959e70a163c3d6d8128cf72f8ae143f87b9d1fd6bb0ad30321116b9c58d69fca9fb33c214f681b664e53d5640abc2fdb972dc62a5571053",
-        ),
+        # BOLT 2:
+        #
+        # Once both nodes have exchanged channel_ready (and optionally announcement_signatures),
+        # the channel can be used to make payments via Hashed Time Locked Contracts.
     ]


### PR DESCRIPTION
Signature exchanges are signed with the node's private key and verified by the counterpart using the node's ID (which is the public key). The signatures should not be the same because the lightning implementation and lnprototest do not have the same private key, or better yet, lnprototest will fake a different private key.

Unfortunately, we lack the tools to easily create this signature, making lnprototest a painful process. Apologies for the inconvenience!

Therefore, we should have a tool to calculate the signatures at some point. But for now, we are leveraging the lightning specification and skipping the announce signature message.

This significantly simplifies the workflow.