### PR TITLE
feat(test): Add a new test to ensure proper signature checking

### DIFF
--- a/tests/test_bolt2-01-open_channel.py
+++ b/tests/test_bolt2-01-open_channel.py
@@ -6,7 +6,6 @@ from lnprototest import (
     ExpectMsg,
     ExpectTx,
     ExpectError,
-    MustNotMsg,
     Msg,
     RawMsg,
     AcceptFunding,
@@ -330,8 +329,5 @@ def test_open_channel_opener_side_wrong_announcement_signatures(runner: Runner) 
             ),
         ),
         ExpectError(),
-        # BOLT 2: The channel is not practically usable until at least one side has
-        # announced its fee levels and expiry, using channel_update.
-        MustNotMsg("channel_update"),
     ]
     run_runner(runner, merge_events_sequences(pre_events, test_events))

--- a/tests/test_bolt2-01-open_channel.py
+++ b/tests/test_bolt2-01-open_channel.py
@@ -328,6 +328,6 @@ def test_open_channel_opener_side_wrong_announcement_signatures(runner: Runner) 
                 "announcement_signatures", dummy_val=dummy_sign
             ),
         ),
-        ExpectError(),
+        ExpectMsg("warning"),
     ]
     run_runner(runner, merge_events_sequences(pre_events, test_events))


### PR DESCRIPTION
Fixes a bug in lnprototest by removing the problematic code outlined in patch [1].

During our investigation of the cln code, we discovered that the message verification was not performed correctly as the BOL 7 suggest. This commit includes a patch [2] that fixes the issue and introduces an integration test to validate that core lightning adheres to the signature verification guidelines outlined in BOLT7.

[1] https://github.com/rustyrussell/lnprototest/pull/91
[2] https://github.com/ElementsProject/lightning/pull/6384

Reported-by: lnprototest (https://github.com/rustyrussell/lnprototest/pull/91)

P.S: now the integration testing should fails because the patch in core lightning is still open