### PR TITLE
fix: Correct error check for expected errors

### DIFF
--- a/lnprototest/event.py
+++ b/lnprototest/event.py
@@ -542,6 +542,16 @@ class ExpectError(PerConnEvent):
         error = runner.check_error(self, self.find_conn(runner))
         if error is None:
             raise EventError(self, "No error found")
+        if runner._is_dummy():
+            return True
+        error = bytes.fromhex(error)
+        msg = Message.read(namespace(), io.BytesIO(error))
+        logging.info(f"message received {msg.messagetype.name}, hex {error.hex()}")
+        if msg.messagetype.name not in "error":
+            raise EventError(
+                self,
+                f"not error found but received `{msg.messagetype.name}` with hex: `{error.hex()}`",
+            )
         return True
 
 

--- a/tests/test_bolt7-02-channel_announcement-failure.py
+++ b/tests/test_bolt7-02-channel_announcement-failure.py
@@ -220,10 +220,13 @@ def test_bad_announcement(runner: Runner) -> None:
                 MustNotMsg("channel_update"),
             ],
             # BOLT #7:
-            #   - otherwise:
-            #    - if `bitcoin_signature_1`, `bitcoin_signature_2`, `node_signature_1` OR
-            #    `node_signature_2` are invalid OR NOT correct:
-            #      - SHOULD fail the connection.
+            # - if the specified chain_hash is unknown to the receiver:
+            #   - MUST ignore the message.
+            # - otherwise:
+            #   - if bitcoin_signature_1, bitcoin_signature_2, node_signature_1 OR node_signature_2 are invalid OR NOT correct:
+            #   - SHOULD send a warning.
+            #   - MAY close the connection.
+            #   - MUST ignore the message.
             [
                 TryAll(
                     [RawMsg(ann_bad_nodesig1)],
@@ -231,7 +234,7 @@ def test_bad_announcement(runner: Runner) -> None:
                     [RawMsg(ann_bad_bitcoinsig1)],
                     [RawMsg(ann_bad_bitcoinsig2)],
                 ),
-                ExpectError(),
+                ExpectMsg("warning"),
             ],
         ),
     ]


### PR DESCRIPTION
This commit addresses an issue with the error checking mechanism. Currently, the `ExpectError` function only verifies the occurrence of an error during the connection, without considering the specific error message expected.

The upcoming changes in [1] will simplify lnprototest, but until then, this fix provides a straightforward and effective solution for checking error messages.

[1] https://github.com/rustyrussell/lnprototest/pull/95