### PR TITLE
feat: Allowing the option to skip the creation of the wallet in bitcoind

### DIFF
--- a/lnprototest/backend/bitcoind.py
+++ b/lnprototest/backend/bitcoind.py
@@ -11,7 +11,7 @@ import logging
 import socket
 
 from contextlib import closing
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 from bitcoin.rpc import RawProxy
 from .backend import Backend
 
@@ -52,7 +52,8 @@ class BitcoinProxy:
 class Bitcoind(Backend):
     """Starts regtest bitcoind on an ephemeral port, and returns the RPC proxy"""
 
-    def __init__(self, basedir: str):
+    def __init__(self, basedir: str, with_wallet: Optional[str] = None):
+        self.with_wallet = with_wallet
         self.rpc = None
         self.proc = None
         self.base_dir = basedir
@@ -119,7 +120,9 @@ class Bitcoind(Backend):
         if self.btc_version >= 210000:
             # Maintains the compatibility between wallet
             # different ln implementation can use the main wallet (?)
-            self.rpc.createwallet("main")  # Automatically loads
+            self.rpc.createwallet(
+                "main" if self.with_wallet is None else self.with_wallet
+            )  # Automatically loads
 
     def __is__bitcoind_ready(self) -> bool:
         """Check if bitcoind is ready during the execution"""

--- a/lnprototest/keyset.py
+++ b/lnprototest/keyset.py
@@ -13,7 +13,6 @@ class KeySet(object):
         delayed_payment_base_secret: str,
         shachain_seed: str,
     ):
-
         from .utils import privkey_expand, check_hex
 
         self.revocation_base_secret = privkey_expand(revocation_base_secret)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lnprototest"
-version = "0.0.4"
+version = "0.0.5-beta.2"
 description = "Spec protocol tests for lightning network implementations"
 authors = ["Rusty Russell <rusty@blockstream.com>", "Vincenzo Palazzo <vincenzopalazzodev@gmail.com>"]
 license = "MIT"

--- a/tests/test_bolt1-01-init.py
+++ b/tests/test_bolt1-01-init.py
@@ -29,6 +29,7 @@ from lnprototest import (
     ExpectDisconnect,
 )
 
+
 # BOLT #1: The sending node:
 # ...
 # - SHOULD NOT set features greater than 13 in `globalfeatures`.


### PR DESCRIPTION
A few years ago, I added this code for compatibility with Bitcoin Core 21.

Now that I am integrating it with the LDK node runner, and LDK can use a wallet to set up a node with Bitcoin Core, we need a way to disable the wallet from Bitcoin Core to keep our integration simpler.

Without this change, Bitcoin Core would have two wallets, and we would need to set up the correct wallet in our architecture.

However, we can simply disable it to avoid this issue.

Fixes https://github.com/rustyrussell/lnprototest/issues/102