### PR TITLE
cln: specify --developer if supported.

### DIFF
--- a/lnprototest/clightning/clightning.py
+++ b/lnprototest/clightning/clightning.py
@@ -70,6 +70,19 @@ class Runner(lnprototest.Runner):
         for flag in config.getoption("runner_args"):
             self.startup_flags.append("--{}".format(flag))
 
+        # Does it support (i.e. require!) --developer?
+        ret = subprocess.run(
+            [
+                "{}/lightningd/lightningd".format(LIGHTNING_SRC),
+                "--developer",
+                "--help",
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        if ret.returncode == 0:
+            self.startup_flags.append("--developer")
+
         opts = (
             subprocess.run(
                 [


### PR DESCRIPTION
This is being added instead of the build-time setting for v23.11.