### PR TITLE
fix: Correct reorg issue in the ln helper function

### DIFF
--- a/docker/Dockerfile.clightning
+++ b/docker/Dockerfile.clightning
@@ -61,7 +61,7 @@ RUN git config --global user.name "John Doe" && \
     cd lightning && \
     poetry config virtualenvs.create false && \
     poetry install && \
-    ./configure --enable-developer && \
+    ./configure && \
     make -j$(nproc)
 
 RUN mkdir lnprototest

--- a/lnprototest/utils/ln_spec_utils.py
+++ b/lnprototest/utils/ln_spec_utils.py
@@ -199,7 +199,7 @@ def open_and_announce_channel_helper(
         ),
         # Mine it and get it deep enough to confirm channel.
         Block(
-            blockheight=103,
+            blockheight=block_height,
             number=stash_field_from_event(
                 "accept_channel", field_name="minimum_depth", dummy_val=3
             ),
@@ -216,9 +216,12 @@ def open_and_announce_channel_helper(
             second_per_commitment_point=local_keyset.per_commit_point(1),
         ),
         # wait confirmations
-        Block(blockheight=103, number=6),
-        # BOLT 2:
         #
-        # Once both nodes have exchanged channel_ready (and optionally announcement_signatures),
-        # the channel can be used to make payments via Hashed Time Locked Contracts.
+        # FIXME: Uh! do you know why this sucks, because lnprototest is lazy evaluated.
+        # This is huggly, and we should change it at some point but this now works.
+        Block(
+            blockheight=lambda runner, event, _: block_height
+            + runner.get_stash(event, "accept_channel").fields["minimum_depth"],
+            number=6,
+        ),
     ]

--- a/tests/test_bolt2-01-open_channel.py
+++ b/tests/test_bolt2-01-open_channel.py
@@ -299,6 +299,10 @@ def test_open_channel_opener_side_wrong_announcement_signatures(runner: Runner) 
     dummy_sign = "138c93afb2013c39f959e70a163c3d6d8128cf72f8ae143f87b9d1fd6bb0ad30321116b9c58d69fca9fb33c214f681b664e53d5640abc2fdb972dc62a5571053"
     short_channel_id = opts["short_channel_id"]
     test_events = [
+        # BOLT 2:
+        #
+        # - Once both nodes have exchanged channel_ready (and optionally announcement_signatures),
+        #   the channel can be used to make payments via Hashed Time Locked Contracts.
         ExpectMsg(
             "announcement_signatures",
             channel_id=channel_id(),


### PR DESCRIPTION
Previously, an unexpected behavior in the ln helper function had gone
unnoticed. However, while Rusty Russell was working on [1], he
discovered a bug in lnprototest.

Specifically, within the helper function that opens a channel, there
was an incorrect way of counting the current block height. Ideally,
this logic should be abstracted elsewhere.

This commit addresses the block height counting
error and resolves the bug identified in [1].

[1] https://github.com/ElementsProject/lightning/pull/6628

Link: https://discord.com/channels/899980449231814676/941465665540325397/1154259454716563537
Reported-by: Rusty Russell <rusty@rustcorp.com.au>
Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>