### PR TITLE
cln: fix the check on the exit code

### DIFF
--- a/lnprototest/clightning/clightning.py
+++ b/lnprototest/clightning/clightning.py
@@ -71,7 +71,7 @@ class Runner(lnprototest.Runner):
             self.startup_flags.append("--{}".format(flag))
 
         # Does it support (i.e. require!) --developer?
-        ret = subprocess.run(
+        ret = subprocess.Popen(
             [
                 "{}/lightningd/lightningd".format(LIGHTNING_SRC),
                 "--developer",
@@ -80,7 +80,7 @@ class Runner(lnprototest.Runner):
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
-        if ret.returncode == 0:
+        if ret.returncode != 0:
             self.startup_flags.append("--developer")
 
         opts = (


### PR DESCRIPTION
The mystery of why pythons do not fail sometimes
is still open to me, but anyway.

This commit is fixing the check on the exit code,
because the subprocess.run will not return
an exit code when the error happens in the command line.

But it will throw an exception, see this example below

```
>>> subprocess.run(["l", "-pp"])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.11/subprocess.py", line 548, in run
    with Popen(*popenargs, **kwargs) as process:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/subprocess.py", line 1026, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.11/subprocess.py", line 1950, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'l'
```

Fixes: https://github.com/rustyrussell/lnprototest/issues/110