### PR TITLE
tests/test_bolt2-30-channel_type-open-accept-tlvs.py: don't test empty channel type.

### DIFF
--- a/tests/test_bolt2-30-channel_type-open-accept-tlvs.py
+++ b/tests/test_bolt2-30-channel_type-open-accept-tlvs.py
@@ -85,65 +85,6 @@ def test_open_channel(runner: Runner, with_proposal: Any) -> None:
     runner.run(test)
 
 
-def test_open_channel_empty_type(runner: Runner, with_proposal: Any) -> None:
-    """Tests for https://github.com/lightningnetwork/lightning-rfc/pull/880"""
-    with_proposal(channel_type_csv)
-
-    # This is not a feature bit, so use support_ to mark it.
-    if runner.has_option("supports_open_accept_channel_type") is None:
-        pytest.skip("Needs supports_open_accept_channel_type")
-
-    local_funding_privkey = "20"
-
-    local_keyset = KeySet(
-        revocation_base_secret="21",
-        payment_base_secret="22",
-        htlc_base_secret="24",
-        delayed_payment_base_secret="23",
-        shachain_seed="00" * 32,
-    )
-
-    test = [
-        Block(blockheight=102, txs=[tx_spendable]),
-        Connect(connprivkey="02"),
-        ExpectMsg("init"),
-        TryAll(
-            # | 12/13 | `option_static_remotekey`        | Static key for remote output
-            Msg("init", globalfeatures="", features=bitfield(13))
-        ),
-        Msg(
-            "open_channel",
-            chain_hash=BitcoinUtils.blockchain_hash(),
-            temporary_channel_id="00" * 32,
-            funding_satoshis=funding_amount_for_utxo(0),
-            push_msat=0,
-            dust_limit_satoshis=546,
-            max_htlc_value_in_flight_msat=4294967295,
-            channel_reserve_satoshis=9998,
-            htlc_minimum_msat=0,
-            feerate_per_kw=253,
-            # We use 5, because core-lightning runner uses 6, so this is different.
-            to_self_delay=5,
-            max_accepted_htlcs=483,
-            funding_pubkey=pubkey_of(local_funding_privkey),
-            revocation_basepoint=local_keyset.revocation_basepoint(),
-            payment_basepoint=local_keyset.payment_basepoint(),
-            delayed_payment_basepoint=local_keyset.delayed_payment_basepoint(),
-            htlc_basepoint=local_keyset.htlc_basepoint(),
-            first_per_commitment_point=local_keyset.per_commit_point(0),
-            channel_flags=1,
-            # We negotiate *down* to a simple non-static channel
-            tlvs="{channel_type={type=}}",
-        ),
-        # BOLT #2
-        #   - if it sets `channel_type`:
-        #     - MUST set it to the `channel_type` from `open_channel`
-        ExpectMsg("accept_channel", tlvs="{channel_type={type=}}"),
-    ]
-
-    runner.run(test)
-
-
 def test_open_channel_bad_type(runner: Runner, with_proposal: Any) -> None:
     """Tests for https://github.com/lightningnetwork/lightning-rfc/pull/880"""
     with_proposal(channel_type_csv)


### PR DESCRIPTION
Modern CLN will reject this, now it requires static remotekey.

