### PR TITLE
meta: fix cln version to 24.05 

### DIFF
--- a/docker/Dockerfile.clightning
+++ b/docker/Dockerfile.clightning
@@ -38,7 +38,7 @@ RUN apt-get -qq update && \
 	wget \
 	gettext \
 	xsltproc \
-	zlib1g-dev \ 
+	zlib1g-dev \
 	jq && \
 	rm -rf /var/lib/apt/lists/*
 
@@ -59,7 +59,8 @@ RUN pip3 install -U pip && \
 RUN git config --global user.name "John Doe" && \
 	git config --global user.email johndoe@example.com && \
 	git clone https://github.com/ElementsProject/lightning.git && \
-	cd lightning && \
+	# FIXME: cln 24.05 is the last version that works with the current lnprototest.
+	cd lightning && git checkout v24.05 && \
 	pip3 install mako --break-system-packages && pip3 install grpcio-tools --break-system-packages && \
 	./configure && \
 	make -j$(nproc)


### PR DESCRIPTION
cln version 24.05 is the last version of core lightning that it is
working with the version of prototest. Most lickly this is a cln
bug described in the following issue [1].

However, we pin the cln version and report the bug to mainline probably
someone will be able to find the real issue in the cln or lnprototest
at some point.

[1] https://github.com/rustyrussell/lnprototest/issues/123