### PR TITLE
fix: using runner_features and stash_field_from_event inside tests

### DIFF
--- a/tests/test_bolt1-02-unknown-messages.py
+++ b/tests/test_bolt1-02-unknown-messages.py
@@ -16,7 +16,11 @@ def test_unknowns(runner: Runner, namespaceoverride: Any) -> None:
     test = [
         Connect(connprivkey="03"),
         ExpectMsg("init"),
-        Msg("init", globalfeatures="", features=""),
+        Msg(
+            "init",
+            globalfeatures=runner.runner_features(globals=True),
+            features=runner.runner_features(),
+        ),
         # BOLT #1:
         # A receiving node:
         #   - upon receiving a message of _odd_, unknown type:
@@ -32,7 +36,11 @@ def test_unknowns_even_message(runner: Runner, namespaceoverride: Any) -> None:
     test = [
         Connect(connprivkey="03"),
         ExpectMsg("init"),
-        Msg("init", globalfeatures="", features=""),
+        Msg(
+            "init",
+            globalfeatures=runner.runner_features(globals=True),
+            features=runner.runner_features(),
+        ),
         # BOLT #1:
         # A receiving node:...
         #   - upon receiving a message of _even_, unknown type:

--- a/tests/test_bolt2-10-add-htlc.py
+++ b/tests/test_bolt2-10-add-htlc.py
@@ -38,6 +38,7 @@ from lnprototest.stash import (
     funding,
     htlc_sigs_to_send,
     htlc_sigs_to_recv,
+    stash_field_from_event,
 )
 from lnprototest.utils import pubkey_of
 from lnprototest.utils.bitcoin_utils import (
@@ -94,16 +95,10 @@ def test_htlc_add(runner: Runner) -> None:
         Block(blockheight=102, txs=[tx_spendable]),
         Connect(connprivkey="02"),
         ExpectMsg("init"),
-        TryAll(
-            Msg("init", globalfeatures="", features=bitfield(data_loss_protect)),
-            Msg("init", globalfeatures="", features=bitfield(static_remotekey)),
-            Msg(
-                "init",
-                globalfeatures="",
-                features=bitfield(static_remotekey, anchor_outputs),
-            ),
-            # And nothing.
-            Msg("init", globalfeatures="", features=""),
+        Msg(
+            "init",
+            globalfeatures=runner.runner_features(globals=True),
+            features=runner.runner_features(),
         ),
         Msg(
             "open_channel",
@@ -135,7 +130,7 @@ def test_htlc_add(runner: Runner) -> None:
             delayed_payment_basepoint=remote_delayed_payment_basepoint(),
             htlc_basepoint=remote_htlc_basepoint(),
             first_per_commitment_point=remote_per_commitment_point(0),
-            minimum_depth=3,
+            minimum_depth=stash_field_from_event("accept_channel", dummy_val=3),
             channel_reserve_satoshis=9998,
         ),
         # Create and stash Funding object and FundingTx
@@ -171,7 +166,13 @@ def test_htlc_add(runner: Runner) -> None:
             "funding_signed", channel_id=channel_id(), signature=commitsig_to_recv()
         ),
         # Mine it and get it deep enough to confirm channel.
-        Block(blockheight=103, number=3, txs=[funding_tx()]),
+        Block(
+            blockheight=103,
+            number=stash_field_from_event(
+                "accept_channel", field_name="minimum_depth", dummy_val=3
+            ),
+            txs=[funding_tx()],
+        ),
         ExpectMsg(
             "channel_ready",
             channel_id=channel_id(),

--- a/tests/test_bolt2-30-channel_type-open-accept-tlvs.py
+++ b/tests/test_bolt2-30-channel_type-open-accept-tlvs.py
@@ -44,13 +44,10 @@ def test_open_channel(runner: Runner, with_proposal: Any) -> None:
         Block(blockheight=102, txs=[tx_spendable]),
         Connect(connprivkey="02"),
         ExpectMsg("init"),
-        TryAll(
-            # BOLT-a12da24dd0102c170365124782b46d9710950ac1 #9:
-            # | 20/21 | `option_anchor_outputs`          | Anchor outputs
-            Msg("init", globalfeatures="", features=bitfield(13, 21)),
-            # BOLT #9:
-            # | 12/13 | `option_static_remotekey`        | Static key for remote output
-            Msg("init", globalfeatures="", features=bitfield(13)),
+        Msg(
+            "init",
+            globalfeatures=runner.runner_features(globals=True),
+            features=runner.runner_features(additional_features=[13]),
         ),
         Msg(
             "open_channel",
@@ -107,15 +104,12 @@ def test_open_channel_bad_type(runner: Runner, with_proposal: Any) -> None:
         Block(blockheight=102, txs=[tx_spendable]),
         Connect(connprivkey="02"),
         ExpectMsg("init"),
-        TryAll(
-            # BOLT-a12da24dd0102c170365124782b46d9710950ac1 #9:
-            # | 20/21 | `option_anchor_outputs`          | Anchor outputs
-            Msg("init", globalfeatures="", features=bitfield(12, 21)),
-            # BOLT #9:
-            # | 12/13 | `option_static_remotekey`        | Static key for remote output
-            Msg("init", globalfeatures="", features=bitfield(12)),
-            # And not.
-            Msg("init", globalfeatures="", features=""),
+        # BOLT #9:
+        # | 12/13 | `option_static_remotekey`        | Static key for remote output
+        Msg(
+            "init",
+            globalfeatures=runner.runner_features(globals=True),
+            features=runner.runner_features(additional_features=[12]),
         ),
         Msg(
             "open_channel",

--- a/tests/test_bolt7-01-channel_announcement-success.py
+++ b/tests/test_bolt7-01-channel_announcement-success.py
@@ -31,14 +31,22 @@ def test_gossip_forget_channel_after_12_blocks(runner: Runner) -> None:
         Block(blockheight=102, txs=[tx_spendable]),
         Connect(connprivkey="03"),
         ExpectMsg("init"),
-        Msg("init", globalfeatures="", features=""),
+        Msg(
+            "init",
+            globalfeatures=runner.runner_features(globals=True),
+            features=runner.runner_features(),
+        ),
         Block(blockheight=103, number=6, txs=[funding_tx]),
         RawMsg(funding.channel_announcement("103x1x0", "")),
         # New peer connects, asking for initial_routing_sync.  We *won't* relay channel_announcement, as there is no
         # channel_update.
         Connect(connprivkey="05"),
         ExpectMsg("init"),
-        Msg("init", globalfeatures="", features="08"),
+        Msg(
+            "init",
+            globalfeatures=runner.runner_features(globals=True),
+            features=runner.runner_features(additional_features=[3]),
+        ),
         MustNotMsg("channel_announcement"),
         Disconnect(),
         RawMsg(
@@ -58,7 +66,11 @@ def test_gossip_forget_channel_after_12_blocks(runner: Runner) -> None:
         # Now we'll relay to a new peer.
         Connect(connprivkey="05"),
         ExpectMsg("init"),
-        Msg("init", globalfeatures="", features="08"),
+        Msg(
+            "init",
+            globalfeatures=runner.runner_features(globals=True),
+            features=runner.runner_features(additional_features=[3]),
+        ),
         ExpectMsg("channel_announcement", short_channel_id="103x1x0"),
         ExpectMsg(
             "channel_update",
@@ -73,7 +85,11 @@ def test_gossip_forget_channel_after_12_blocks(runner: Runner) -> None:
         Block(blockheight=109, number=13, txs=[funding.close_tx(200, "99")]),
         Connect(connprivkey="05"),
         ExpectMsg("init"),
-        Msg("init", globalfeatures="", features="08"),
+        Msg(
+            "init",
+            globalfeatures=runner.runner_features(globals=True),
+            features=runner.runner_features(additional_features=[3]),
+        ),
         MustNotMsg("channel_announcement"),
         MustNotMsg("channel_update"),
     ]

--- a/tests/test_bolt7-02-channel_announcement-failure.py
+++ b/tests/test_bolt7-02-channel_announcement-failure.py
@@ -43,7 +43,11 @@ def test_premature_channel_announcement(runner: Runner) -> None:
         Block(blockheight=102, txs=[tx_spendable]),
         Connect(connprivkey="03"),
         ExpectMsg("init"),
-        Msg("init", globalfeatures="", features=""),
+        Msg(
+            "init",
+            globalfeatures=runner.runner_features(globals=True),
+            features=runner.runner_features(),
+        ),
         # txid 189c40b0728f382fe91c87270926584e48e0af3a6789f37454afee6c7560311d
         Block(blockheight=103, txs=[funding_tx]),
         TryAll(
@@ -72,7 +76,11 @@ def test_premature_channel_announcement(runner: Runner) -> None:
         # New peer connects, asking for initial_routing_sync.  We *won't* relay channel_announcement.
         Connect(connprivkey="05"),
         ExpectMsg("init"),
-        Msg("init", globalfeatures="", features="08"),
+        Msg(
+            "init",
+            globalfeatures=runner.runner_features(globals=True),
+            features=runner.runner_features(additional_features=[3]),
+        ),
         MustNotMsg("channel_announcement"),
         MustNotMsg("channel_update"),
     ]
@@ -144,7 +152,11 @@ def test_bad_announcement(runner: Runner) -> None:
         Block(blockheight=102, txs=[tx_spendable]),
         Connect(connprivkey="03"),
         ExpectMsg("init"),
-        Msg("init", globalfeatures="", features=""),
+        Msg(
+            "init",
+            globalfeatures=runner.runner_features(globals=True),
+            features=runner.runner_features(),
+        ),
         # txid 189c40b0728f382fe91c87270926584e48e0af3a6789f37454afee6c7560311d
         Block(blockheight=103, number=6, txs=[funding_tx]),
         TryAll(
@@ -215,7 +227,11 @@ def test_bad_announcement(runner: Runner) -> None:
                 # New peer connects, asking for initial_routing_sync.  We *won't* relay channel_announcement.
                 Connect(connprivkey="05"),
                 ExpectMsg("init"),
-                Msg("init", globalfeatures="", features="08"),
+                Msg(
+                    "init",
+                    globalfeatures=runner.runner_features(globals=True),
+                    features=runner.runner_features(additional_features=[3]),
+                ),
                 MustNotMsg("channel_announcement"),
                 MustNotMsg("channel_update"),
             ],

--- a/tests/test_bolt7-10-gossip-filter.py
+++ b/tests/test_bolt7-10-gossip-filter.py
@@ -14,14 +14,14 @@ from lnprototest import (
     Funding,
     bitfield,
 )
-import unittest
+import pytest
 import time
 from lnprototest.utils import utxo, tx_spendable
 
 
 def test_gossip_timestamp_filter(runner: Runner) -> None:
     if runner.has_option("option_gossip_queries") is None:
-        unittest.SkipTest("Needs option_gossip_queries")
+        pytest.skip("Needs option_gossip_queries")
 
     funding1, funding1_tx = Funding.from_utxo(
         *utxo(0),
@@ -46,7 +46,11 @@ def test_gossip_timestamp_filter(runner: Runner) -> None:
         Block(blockheight=102, txs=[tx_spendable]),
         Connect(connprivkey="03"),
         ExpectMsg("init"),
-        Msg("init", globalfeatures="", features=""),
+        Msg(
+            "init",
+            globalfeatures=runner.runner_features(globals=True),
+            features=runner.runner_features(),
+        ),
         # txid 189c40b0728f382fe91c87270926584e48e0af3a6789f37454afee6c7560311d
         Block(blockheight=103, number=6, txs=[funding1_tx]),
         RawMsg(funding1.channel_announcement("103x1x0", "")),
@@ -61,7 +65,11 @@ def test_gossip_timestamp_filter(runner: Runner) -> None:
         ExpectMsg("init"),
         # BOLT #9:
         # | 6/7   | `gossip_queries`                 | More sophisticated gossip control
-        Msg("init", globalfeatures="", features=bitfield(6)),
+        Msg(
+            "init",
+            globalfeatures=runner.runner_features(globals=True),
+            features=runner.runner_features(additional_features=[6]),
+        ),
         Msg(
             "gossip_timestamp_filter",
             chain_hash="06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f",
@@ -90,7 +98,11 @@ def test_gossip_timestamp_filter(runner: Runner) -> None:
         # New peer connects, asks for gossip_timestamp_filter=all.  update and node announcement will be relayed.
         Connect(connprivkey="05"),
         ExpectMsg("init"),
-        Msg("init", globalfeatures="", features=bitfield(6)),
+        Msg(
+            "init",
+            globalfeatures=runner.runner_features(globals=True),
+            features=runner.runner_features(additional_features=[6]),
+        ),
         Msg(
             "gossip_timestamp_filter",
             chain_hash="06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f",
@@ -110,7 +122,11 @@ def test_gossip_timestamp_filter(runner: Runner) -> None:
         #    `timestamp_range`.
         Connect(connprivkey="05"),
         ExpectMsg("init"),
-        Msg("init", globalfeatures="", features=bitfield(6)),
+        Msg(
+            "init",
+            globalfeatures=runner.runner_features(globals=True),
+            features=runner.runner_features(additional_features=[6]),
+        ),
         Msg(
             "gossip_timestamp_filter",
             chain_hash="06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f",
@@ -123,7 +139,11 @@ def test_gossip_timestamp_filter(runner: Runner) -> None:
         Disconnect(),
         Connect(connprivkey="05"),
         ExpectMsg("init"),
-        Msg("init", globalfeatures="", features=bitfield(6)),
+        Msg(
+            "init",
+            globalfeatures=runner.runner_features(globals=True),
+            features=runner.runner_features(additional_features=[6]),
+        ),
         Msg(
             "gossip_timestamp_filter",
             chain_hash="06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f",
@@ -137,7 +157,11 @@ def test_gossip_timestamp_filter(runner: Runner) -> None:
         # These two succeed in getting the gossip, then stay connected for next test.
         Connect(connprivkey="05"),
         ExpectMsg("init"),
-        Msg("init", globalfeatures="", features=bitfield(6)),
+        Msg(
+            "init",
+            globalfeatures=runner.runner_features(globals=True),
+            features=runner.runner_features(additional_features=[6]),
+        ),
         Msg(
             "gossip_timestamp_filter",
             chain_hash="06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f",
@@ -151,7 +175,11 @@ def test_gossip_timestamp_filter(runner: Runner) -> None:
         ),
         Connect(connprivkey="06"),
         ExpectMsg("init"),
-        Msg("init", globalfeatures="", features=bitfield(6)),
+        Msg(
+            "init",
+            globalfeatures=runner.runner_features(globals=True),
+            features=runner.runner_features(additional_features=[6]),
+        ),
         Msg(
             "gossip_timestamp_filter",
             chain_hash="06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f",

--- a/tests/test_bolt7-20-query_channel_range.py
+++ b/tests/test_bolt7-20-query_channel_range.py
@@ -21,7 +21,7 @@ from lnprototest import (
 )
 from lnprototest.utils import BitcoinUtils, tx_spendable, utxo
 from typing import Optional
-import unittest
+import pytest
 import time
 import io
 import zlib
@@ -165,7 +165,7 @@ def update_checksums(update1: Optional[Message], update2: Optional[Message]) -> 
 
 def test_query_channel_range(runner: Runner) -> None:
     if runner.has_option("option_gossip_queries") is None:
-        unittest.SkipTest("Needs option_gossip_queries")
+        pytest.skip("Needs option_gossip_queries")
 
     funding1, funding1_tx = Funding.from_utxo(
         *utxo(0),
@@ -239,7 +239,11 @@ def test_query_channel_range(runner: Runner) -> None:
         Block(blockheight=109, number=6, txs=[funding2_tx]),
         Connect(connprivkey="03"),
         ExpectMsg("init"),
-        Msg("init", globalfeatures="", features=""),
+        Msg(
+            "init",
+            globalfeatures=runner.runner_features(globals=True),
+            features=runner.runner_features(),
+        ),
         RawMsg(funding1.channel_announcement("103x1x0", "")),
         RawMsg(update_103x1x0_LOCAL),
         RawMsg(funding2.channel_announcement("109x1x0", "")),
@@ -250,7 +254,11 @@ def test_query_channel_range(runner: Runner) -> None:
         ExpectMsg("init"),
         # BOLT #9:
         # | 6/7   | `gossip_queries`                 | More sophisticated gossip control
-        Msg("init", globalfeatures="", features=bitfield(7)),
+        Msg(
+            "init",
+            globalfeatures=runner.runner_features(globals=True),
+            features=runner.runner_features(additional_features=[7]),
+        ),
         TryAll(
             # No queries?  Must not get anything.
             [


### PR DESCRIPTION
Tests are updated to use `runner_features` and `stash_field_from_event`, this allows the tests to support multiple lightning implementations at the same time.