### PR TITLE
tests: include the test for the tests

### DIFF
--- a/tests/test_bolt1-02-unknown-messages.py
+++ b/tests/test_bolt1-02-unknown-messages.py
@@ -5,7 +5,7 @@ import pyln.spec.bolt1
 
 from typing import Any
 
-from lnprototest import TryAll, Connect, ExpectMsg, Msg, RawMsg, Runner
+from lnprototest import Connect, ExpectMsg, Msg, RawMsg, Runner
 from lnprototest.event import ExpectDisconnect
 from lnprototest.utils import run_runner
 


### PR DESCRIPTION
Some implementations send an error message and, at the same time, will close the connection. Locally, this will cause a reading from a closed socket.

However, ldk now has a different life cycle for the connection, and we should receive the error message before.

```
 lnprototest.errors.EventError: `Peer did not disconnect` on event [{"event": "ExpectDisconnect", "file": "test_bolt2-01-open_channel.py", "pos": "345"},]
=========================== short test summary info ============================
FAILED ../lnprototest/tests/test_bolt2-01-open_channel.py::test_open_channel_opener_side_wrong_announcement_signatures
============= 1 failed, 29 passed, 17 skipped in 96.15s (0:01:36) ==============
```

Fixes https://github.com/rustyrussell/lnprototest/issues/134
Reported-by: @Psycho-Pirate